### PR TITLE
fixes TIPOFF_CONFIG sql statement

### DIFF
--- a/src/tipoff/functions.py
+++ b/src/tipoff/functions.py
@@ -22,7 +22,7 @@ def get_tipoff_data():
         database=config.DATABASE,
     )
     cursor = connection.cursor()
-    cursor.execute(config.TIPOFF_CONFIG)
+    cursor.execute(TIPOFF_CONFIG)
     df = pd.DataFrame(
         [tuple(row) for row in cursor.fetchall()],
         columns=[desc[0] for desc in cursor.description],


### PR DESCRIPTION
Accidentally put config.TIPOFF_CONFIG when it should have just been TIPOFF_CONFIG